### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CueTableReloader
 A really handy class that automatically figures out insertions, deletions, moves, and reloads in UITableView 
 based on unique item keys.
 
-#Usage
+# Usage
 1. Ensure that your data model consists of a two level array: `[sections][rows]`. 
 1. Implement the `CueTableItem` protocol on all of your data objects and ensure that all of your keys are 100% unique.
 1. Replace all reloadData calls with calls to CueTableReloader's `reloadData:animated:`.
@@ -18,11 +18,11 @@ CueTableReloader *reloader = [[CueTableReloader alloc] initWithTableView:tableVi
 [reloader reloadData:sections animated:YES];
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#Limitations
+# Limitations
 This class works very well for insertions and deletions within the same section. It does its best when existing items reorder
 relative to each other. Any travel from one section to another is treated as a delete+insert.
 
-####Known Bugs
+#### Known Bugs
 * Some complex transitions involving reordering can cause a non-animated reload. Pull requests welcome.
 
 # License


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
